### PR TITLE
Allow a cache provider to be passed to LayerSimpleObject via configure method

### DIFF
--- a/packages/stratocacher-layer-simple-object/src/index.js
+++ b/packages/stratocacher-layer-simple-object/src/index.js
@@ -13,8 +13,12 @@ export default class LayerSimpleObject extends Layer {
 		Object.keys(CACHE).forEach(k => delete CACHE[k]);
 	}
 
+	getCache() {
+		return (this.opt.cacheProvider || (() => CACHE))();
+	}
+
 	get() {
-		let val = CACHE[this.key];
+		let val = this.getCache()[this.key];
 		if (this.opt.copy) {
 			val = JSON.parse(val);
 		}
@@ -27,7 +31,7 @@ export default class LayerSimpleObject extends Layer {
 		if (this.opt.copy) {
 			val = JSON.stringify(val);
 		}
-		CACHE[this.key] = val;
+		this.getCache()[this.key] = val;
 		return Q(); // We're synchronous but need to return a promise.
 	}
 }

--- a/packages/stratocacher-layer-simple-object/test/options.js
+++ b/packages/stratocacher-layer-simple-object/test/options.js
@@ -30,4 +30,19 @@ describe("A LayerSimpleObject instance", () => {
 			done();
 		});
 	});
+
+	it("accepts a cacheProvider in configuration", done => {
+		const obj = { foo: "bar" }
+		const myCache = {};
+		LayerSimpleObject.configure({cacheProvider: () => myCache});
+
+		const layer = new LayerSimpleObject({key: "A"});
+
+		layer.set(obj).then(() => layer.get()).then(() => {
+			expect(myCache).toBeDefined();
+			expect(myCache.A).toBeDefined();
+			expect(myCache.A.v).toEqual(obj);
+			done();
+		}).catch(done);
+	});
 });


### PR DESCRIPTION
Allows user to specify a cache provider, via the configure method, i.e.


```
const myCache = {};
const cacheProvider = () => myCache;
LayerSimpleObject.configure({cacheProvider});

//layer stores stuff in myCache
const layer = new LayerSimpleObject({key: "A"});
```
