### PR TITLE
Add compression option for Dynamo layer

### DIFF
--- a/packages/stratocacher-layer-dynamo/package.json
+++ b/packages/stratocacher-layer-dynamo/package.json
@@ -26,6 +26,7 @@
     "homepage": "https://github.com/redfin/stratocacher/packages/stratocacher-layer-dynamo#readme",
     "dependencies": {
         "aws-sdk": "^2.289.0",
+        "lzutf8": "^0.5.5",
         "q": "^1.5.1",
         "stratocacher": "^0.1.0"
     },

--- a/packages/stratocacher-layer-dynamo/test/index.js
+++ b/packages/stratocacher-layer-dynamo/test/index.js
@@ -1,22 +1,32 @@
-const mockRequire = require("mock-require");
-const cache = {};
+import lzutf8 from "lzutf8";
+import mockRequire from "mock-require";
+
+let cache = {};
 
 //Dynamo client mock
 function DynamoDB() {
 	this.getItem = (params, cb) => {
-		const key = params.Key.key.S;
-		const tableName = params.TableName;
-		const Item = cache[tableName] && cache[tableName][key];
-		cb(Item ? {Item} : undefined);
+		try {
+			const key = params.Key.key.S;
+			const tableName = params.TableName;
+			const Item = cache[tableName] && cache[tableName][key];
+			cb(undefined, Item ? {Item} : undefined);
+		} catch (e) {
+			cb(e);
+		}
 	}
 
 	this.putItem = (params, cb) => {
-		const key = params.Item.key.S;
-		const tableName = params.tableName;
+		try {
+			const key = params.Item.key.S;
+			const tableName = params.TableName;
 
-		if (!cache[tableName]) cache[tableName] = {};
-
-		cb(cache[tableName][key] = params.Item);
+			if (!cache[tableName]) cache[tableName] = {};
+			cache[tableName][key] = params.Item
+			cb();
+		} catch (e) {
+			cb(e);
+		}
 	}
 }
 
@@ -38,22 +48,31 @@ describe("A LayerDynamo instance", () => {
 		});
 	});
 
+	beforeEach(() => {
+		cache = {}
+	})
+
 	it("sets and gets a value", done => {
 		const layer = new LayerDynamo({key: "A"});
 
-		layer.set(obj).then(() => layer.get()).then(() => {
-			expect(layer.val).toEqual(obj);
-			done();
-		}).catch(done);
+		layer.set(obj)
+			.then(() => layer.get())
+			.then(() => {
+				expect(layer.val).toEqual(obj);
+				done();
+			})
+			.catch(e => done.fail(e));
 	});
 
 	it("returns undefined for a cache miss", done => {
 		const layer = new LayerDynamo({key: "A"});
 
-		layer.get().then(() => {
-			expect(layer.val).toBeUndefined();
-			done();
-		}).catch(done);
+		layer.get()
+			.then(() => {
+				expect(layer.val).toBeUndefined();
+				done();
+			})
+			.catch(e => done.fail(e));
 	});
 
 	it("can be configured to not parse JSON", done => {
@@ -62,17 +81,43 @@ describe("A LayerDynamo instance", () => {
 			tableName: "cache",
 			awsConfig: {
 				accessKeyId: "xxxx",
-				secretAccessKey: "xxxx",
+				secretAccessKey: "xxx",
 				region: "us-west-2",
 			},
 		});
 
 		const layer = new LayerDynamo({key: "A"});
 
-		layer.set(obj).get().then(() => {
-			expect(layer.val).toEqual("[object Object]");
-			done();
-		}).catch(done);
+		layer.set(obj)
+			.then(() => layer.get())
+			.then(() => {
+				expect(layer.val).toEqual("[object Object]");
+				done();
+			})
+			.catch(e => done.fail(e));
+	});
+
+	it("can be configured to use compression", done => {
+		LayerDynamo.configure({
+			compress: true,
+			tableName: "cache",
+			awsConfig: {
+				accessKeyId: "xxx",
+				secretAccessKey: "xxx",
+				region: "us-west-2",
+			},
+		});
+
+		const layer = new LayerDynamo({key: "A"});
+
+		layer.set(obj)
+			.then(() => layer.get())
+			.then(() => {
+				expect(layer.val).toEqual(obj);
+				expect(cache.cache.A.v.B).toEqual(lzutf8.compress(JSON.stringify(obj)));
+				done();
+			})
+			.catch(e => done.fail(e));
 	});
 
 });


### PR DESCRIPTION
* Compression can be enabled using `LayerDynamo.configure({compress: true});`
* Uses lzutf8 default string compression (LZ77): https://www.npmjs.com/package/lzutf8
* Add a flag to the schema (c) that indicates whether the value is compressed. Also add a flag (json) that indicates whether the value is JSON.