### PR TITLE
 Add timeout for DynamoDB requests

### DIFF
--- a/packages/stratocacher-layer-dynamo/src/index.js
+++ b/packages/stratocacher-layer-dynamo/src/index.js
@@ -35,7 +35,6 @@ function emitError(message) {
 	Config options:
 	tableName: The name of your DynamoDB table
 	awsConfig: aws-sdk config.
-	json: treat values as JSON. (default = true)
 	compress: compress values (default = false)
 */
 export default class LayerDynamo extends Layer {
@@ -108,9 +107,6 @@ export default class LayerDynamo extends Layer {
 				c: {
 					BOOL: Boolean(this.opt.compress),
 				},
-				json: {
-					BOOL: Boolean(this.opt.json !== false),
-				},
 			},
 			TableName: this.opt.tableName,
 		};
@@ -118,17 +114,11 @@ export default class LayerDynamo extends Layer {
 
 	/*
 		returns a typed value: {<type toke>: value},
-		If opt.json is false, coerced val to string,
-		otherwise uses JSON.stringify.
 		If opt.compress is true, compresses value and
 		uses type binary, otherwise stores val as a string.
 	*/
 	makeValue(v) {
-		if (this.opt.json !== false) {
-			v = JSON.stringify(v);
-		} else {
-			v = String(v);
-		}
+		v = JSON.stringify(v);
 
 		const typedV = {};
 
@@ -142,7 +132,7 @@ export default class LayerDynamo extends Layer {
 		return typedV;
 	}
 
-	parseValue({v, c, json}) {
+	parseValue({v, c}) {
 
 		if (c && c.BOOL) { // c flag tells us this value is compressed
 			if (!v.B) {
@@ -159,11 +149,7 @@ export default class LayerDynamo extends Layer {
 			v = v.S;
 		}
 
-		if (json && json.BOOL) {
-			v = JSON.parse(v);
-		}
-
-		return v;
+		return JSON.parse(v);
 	}
 
 }

--- a/packages/stratocacher-layer-dynamo/test/index.js
+++ b/packages/stratocacher-layer-dynamo/test/index.js
@@ -3,14 +3,28 @@ import mockRequire from "mock-require";
 
 let cache = {};
 
+function getConfig(overrides) {
+	return Object.assign({
+		tableName: "cache",
+		awsConfig: {
+			accessKeyId: "xxxxx",
+			secretAccessKey: "xxxx",
+			region: "us-west-2",
+		},
+	}, overrides);
+}
+
 //Dynamo client mock
 function DynamoDB() {
 	this.getItem = (params, cb) => {
 		try {
 			const key = params.Key.key.S;
 			const tableName = params.TableName;
-			const Item = cache[tableName] && cache[tableName][key];
-			cb(undefined, Item ? {Item} : undefined);
+
+			if (cache[tableName]) {
+				const Item = cache[tableName] && cache[tableName][key];
+				cb(undefined, Item ? {Item} : undefined);
+			}
 		} catch (e) {
 			cb(e);
 		}
@@ -20,10 +34,10 @@ function DynamoDB() {
 		try {
 			const key = params.Item.key.S;
 			const tableName = params.TableName;
-
-			if (!cache[tableName]) cache[tableName] = {};
-			cache[tableName][key] = params.Item
-			cb();
+			if (cache[tableName]) {
+				cache[tableName][key] = params.Item;
+				cb();
+			}
 		} catch (e) {
 			cb(e);
 		}
@@ -38,18 +52,12 @@ describe("A LayerDynamo instance", () => {
 
 	beforeAll(() => {
 		LayerDynamo = require("../lib/index.js").default;
-		LayerDynamo.configure({
-			tableName: "cache",
-			awsConfig: {
-				accessKeyId: "xxxx",
-				secretAccessKey: "xxxx",
-				region: "us-west-2",
-			},
-		});
+		LayerDynamo.configure(getConfig());
 	});
 
 	beforeEach(() => {
-		cache = {}
+		cache = {"cache": {}};
+		LayerDynamo.configure(getConfig());
 	})
 
 	it("sets and gets a value", done => {
@@ -75,38 +83,9 @@ describe("A LayerDynamo instance", () => {
 			.catch(e => done.fail(e));
 	});
 
-	it("can be configured to not parse JSON", done => {
-		LayerDynamo.configure({
-			json: false,
-			tableName: "cache",
-			awsConfig: {
-				accessKeyId: "xxxx",
-				secretAccessKey: "xxx",
-				region: "us-west-2",
-			},
-		});
-
-		const layer = new LayerDynamo({key: "A"});
-
-		layer.set(obj)
-			.then(() => layer.get())
-			.then(() => {
-				expect(layer.val).toEqual("[object Object]");
-				done();
-			})
-			.catch(e => done.fail(e));
-	});
-
 	it("can be configured to use compression", done => {
-		LayerDynamo.configure({
-			compress: true,
-			tableName: "cache",
-			awsConfig: {
-				accessKeyId: "xxx",
-				secretAccessKey: "xxx",
-				region: "us-west-2",
-			},
-		});
+
+		LayerDynamo.configure(getConfig({compress: true}));
 
 		const layer = new LayerDynamo({key: "A"});
 
@@ -120,4 +99,37 @@ describe("A LayerDynamo instance", () => {
 			.catch(e => done.fail(e));
 	});
 
+	it("throws an error if set operation times out", done => {
+
+		LayerDynamo.configure(getConfig({
+			tableName: "non-existent",
+			requestTimeout: 200,
+		}));
+
+		const layer = new LayerDynamo({key: "A"});
+
+		layer.set(obj)
+			.then(() => done.fail("Operation should have timed out."))
+			.catch(e => {
+				expect(e.message).toEqual("Timed out after 200 ms");
+				done();
+			});
+	});
+
+	it("throws an error if get operation times out", done => {
+
+		LayerDynamo.configure(getConfig({
+			tableName: "non-existent",
+			requestTimeout: 200,
+		}));
+
+		const layer = new LayerDynamo({key: "A"});
+
+		layer.get(obj)
+			.then(() => done.fail("Operation should have timed out."))
+			.catch(e => {
+				expect(e.message).toEqual("Timed out after 200 ms");
+				done();
+			});
+	});
 });


### PR DESCRIPTION
* Timeout defaults to 3000ms, but can be configured via the `requestTimeout` param.
* Also remove no-JSON option. 