### PR TITLE
Add shouldCache hook to wrap function

### DIFF
--- a/packages/stratocacher/src/dev/layer-test-object.js
+++ b/packages/stratocacher/src/dev/layer-test-object.js
@@ -2,7 +2,8 @@ import Layer from "../layer-class";
 import Q     from "q";
 import _     from "lodash";
 
-const CACHE = {};
+export const CACHE = {};
+
 export default class LayerTestObject extends Layer {
 	static reset() {
 		_.forEach(CACHE, (v, k) => delete CACHE[k])

--- a/packages/stratocacher/src/wrap.js
+++ b/packages/stratocacher/src/wrap.js
@@ -74,15 +74,9 @@ export default function wrap(opts, func){
 				});
 		}
 
-		const set = (layers, val) => {
-
-			if (!shouldCache(val)) return;
-
-			if (Array.isArray(layers)) {
-				layers.forEach(layer => layer.set(val));
-			}
-			else {
-				layers.set(val);
+		const set = (layer, val) => {
+			if (shouldCache(val)) {
+				layer.set(val);
 			}
 		}
 
@@ -129,7 +123,7 @@ export default function wrap(opts, func){
 					// layers.
 					if (cur.red) {
 						bld().then((val) => {
-							set(fix, val);
+							fix.forEach(layer => set(layer, val));
 						}).catch(() => {
 							time('error.background', new Date - _t0);
 						});

--- a/packages/stratocacher/test/unwrap.js
+++ b/packages/stratocacher/test/unwrap.js
@@ -3,6 +3,7 @@ const wrap = require('../lib/wrap').default;
 const events = require('../lib/events').default;
 const Registry = require('../lib/registry').default;
 const LayerTestObject = require('../lib/dev/layer-test-object').default;
+const CACHE = require('../lib/dev/layer-test-object').CACHE;
 const {ONE_HOUR} = require('../lib/constants');
 
 describe("An unwrapped function", () => {
@@ -43,7 +44,43 @@ describe("An unwrapped function", () => {
 		.then(get)
 		.then(v => expect(v).toBe(2))
 		.then(() => expect(handler).not.toHaveBeenCalled())
-		.then(done)
+		.then(done);
+
+	});
+
+	it("accepts a shouldCache hook", done => {
+		let i = 0;
+		const handler = jasmine.createSpy('handler');
+		const shouldCache = jasmine.createSpy('shouldCache');
+		events.on('time', handler);
+
+		const A = wrap({
+			ttl         : ONE_HOUR,
+			layers      : [LayerTestObject],
+			shouldCache : (val) => {
+				shouldCache();
+				return val !== 1;
+			},
+		}, function A() {
+			return ++i;
+		})
+
+		// No arguments.
+		const get = () => A()
+
+		Q()
+			.then(get)
+			.then(v => expect(v).toBe(1))
+			.then(() => expect(handler).toHaveBeenCalled())
+			.then(() => expect(shouldCache).toHaveBeenCalled())
+			.then(() => expect(Object.keys(CACHE).length).toBe(0))
+			.then(() => handler.calls.reset())
+			.then(get)
+			.then(v => expect(v).toBe(2))
+			.then(() => expect(CACHE['0_A_0'].v).toBe(2))
+			.then(() => expect(handler).toHaveBeenCalled())
+			.then(() => expect(shouldCache).toHaveBeenCalled())
+			.then(done);
 	});
 
 	it("can be re-wrapped", done => {


### PR DESCRIPTION
* `wrap` accepts a `shouldCache` that acts as a filter function on values going into the cache.

* `shouldCache` accepts the value returned by the upstream data fetch (`func`) and returns a boolean. If `shouldCache` returns true, the value is cached. If `shouldCache` returns false, the value is not cached.

* This is useful for situations in which you don't want to cache certain data.