### PR TITLE
Replace `shouldCache` hook with `transform` hook

### DIFF
--- a/packages/stratocacher/src/wrap.js
+++ b/packages/stratocacher/src/wrap.js
@@ -43,7 +43,7 @@ export default function wrap(opts, func){
 		ttr         = ttl * DEFAULT_TTR_RATIO,
 		layers      = [],
 		before      = _ => Q(_),   // Munge arguments.
-		shouldCache = () => true,  // Should we cache the response from func?
+		transform   = _ => _,      // Transform response from func. undefined won't be cached.
 		after       = _ => Q(_),   // Munge response.
 		force       = () => false, // Force a miss.
 	} = opts;
@@ -75,8 +75,9 @@ export default function wrap(opts, func){
 		}
 
 		const set = (layer, val) => {
-			if (shouldCache(val)) {
-				layer.set(val);
+			const transformed = transform(val);
+			if (typeof transformed !== 'undefined') {
+				layer.set(transformed);
 			}
 		}
 

--- a/packages/stratocacher/src/wrap.js
+++ b/packages/stratocacher/src/wrap.js
@@ -43,7 +43,7 @@ export default function wrap(opts, func){
 		ttr         = ttl * DEFAULT_TTR_RATIO,
 		layers      = [],
 		before      = _ => Q(_),   // Munge arguments.
-		transform   = _ => _,      // Transform response from func. undefined won't be cached.
+		preCache    = _ => _,      // Applied to response from func. Undefined isn't cached.
 		after       = _ => Q(_),   // Munge response.
 		force       = () => false, // Force a miss.
 	} = opts;
@@ -75,9 +75,9 @@ export default function wrap(opts, func){
 		}
 
 		const set = (layer, val) => {
-			const transformed = transform(val);
-			if (typeof transformed !== 'undefined') {
-				layer.set(transformed);
+			val = preCache(val);
+			if (typeof val !== 'undefined') {
+				layer.set(val);
 			}
 		}
 

--- a/packages/stratocacher/test/unwrap.js
+++ b/packages/stratocacher/test/unwrap.js
@@ -48,17 +48,17 @@ describe("An unwrapped function", () => {
 
 	});
 
-	it("accepts a transform hook", done => {
+	it("accepts a preCache hook", done => {
 		const data0 = {foo: 0, bar: 1};
 		const handler = jasmine.createSpy('handler');
-		const transform = jasmine.createSpy('transform');
+		const preCache = jasmine.createSpy('preCache');
 		events.on('time', handler);
 
 		const A = wrap({
 			ttl         : ONE_HOUR,
 			layers      : [LayerTestObject],
-			transform : (val) => {
-				transform();
+			preCache : (val) => {
+				preCache();
 				return val.foo === 1 ? undefined : Object.assign(val, {baz: 2});
 			},
 		}, function A() {
@@ -72,14 +72,14 @@ describe("An unwrapped function", () => {
 			.then(get)
 			.then(v => expect(v).toBe(data0))
 			.then(() => expect(handler).toHaveBeenCalled())
-			.then(() => expect(transform).toHaveBeenCalled())
+			.then(() => expect(preCache).toHaveBeenCalled())
 			.then(() => expect(Object.keys(CACHE).length).toBe(0))
 			.then(() => handler.calls.reset())
 			.then(get)
 			.then(v => expect(v.foo).toBe(2) && expect(v.baz).toBe(2))
 			.then(() => expect(CACHE['0_A_0'].v.baz).toBe(2))
 			.then(() => expect(handler).toHaveBeenCalled())
-			.then(() => expect(transform).toHaveBeenCalled())
+			.then(() => expect(preCache).toHaveBeenCalled())
 			.then(done);
 	});
 


### PR DESCRIPTION
* `transform` hook applies a function to values returned from upstream.
* If `transform` returns `undefined`, the value is not cached.