### PR TITLE
Use JSON.stringify() instead of .join() to avoid key collision

### DIFF
--- a/packages/stratocacher/src/keys.js
+++ b/packages/stratocacher/src/keys.js
@@ -23,5 +23,5 @@ export function makeKey({
 			return null;
 		}
 	}
-	return pieces.join('_');
+	return JSON.stringify(pieces);
 }

--- a/packages/stratocacher/test/unwrap.js
+++ b/packages/stratocacher/test/unwrap.js
@@ -77,7 +77,7 @@ describe("An unwrapped function", () => {
 			.then(() => handler.calls.reset())
 			.then(get)
 			.then(v => expect(v).toBe(2))
-			.then(() => expect(CACHE['0_A_0'].v).toBe(2))
+			.then(() => expect(CACHE['[0,"A",0]'].v).toBe(2))
 			.then(() => expect(handler).toHaveBeenCalled())
 			.then(() => expect(shouldCache).toHaveBeenCalled())
 			.then(done);


### PR DESCRIPTION
Fixes #9.
~~[Edit]: I've also removed the gulp-nsp module. The node security service has [shut down](https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting). The replacement is [npm audit](https://docs.npmjs.com/auditing-package-dependencies-for-security-vulnerabilities), but the workflow is different, and I think it calls for a separate issue to determine that workflow.~~