### PR TITLE
Remove now dead nsp

### DIFF
--- a/lib/shared-gulpfile.babel.js
+++ b/lib/shared-gulpfile.babel.js
@@ -1,7 +1,6 @@
 const babel = require('gulp-babel');
 const del = require('del');
 const gulp = require('gulp');
-const nsp = require('gulp-nsp');
 const path = require('path');
 const eslint = require('gulp-eslint');
 const jasmine = require('gulp-jasmine');
@@ -19,8 +18,6 @@ const cli = meow(`
 		v: 'verbose',
 	},
 });
-
-gulp.task('nsp', (cb) => nsp({package: path.resolve('package.json')}, cb));
 
 gulp.task('compile', () => gulp.src(["src/**/*.js"])
 	.pipe(babel())
@@ -54,5 +51,5 @@ gulp.task('bench', ['compile'], () => gulp.src("bench/**/*.js", {read:false})
 	.pipe(matcha())
 );
 
-gulp.task('prepublish', ['nsp', 'compile']);
+gulp.task('prepublish', ['compile']);
 gulp.task('test', ['eslint', 'jasmine']);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "gulp-eslint": "^5.0.0",
     "gulp-jasmine": "^4.0.0",
     "gulp-matcha": "^1.2.0",
-    "gulp-nsp": "^2.4.1",
     "lerna": "^2.11.0",
     "meow": "^3.7.0"
   }


### PR DESCRIPTION
The node security service has [shut down](https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting). The replacement is [npm audit](https://docs.npmjs.com/auditing-package-dependencies-for-security-vulnerabilities), but the workflow is different, and I think it calls for a separate issue (#17) to determine that workflow.